### PR TITLE
Categories should contain various hardware types that belong to that category, while still each hardware type can have multiple instances.

### DIFF
--- a/app/inmemory/app/annotations.cds
+++ b/app/inmemory/app/annotations.cds
@@ -1,5 +1,32 @@
 using { makerspaceInventorySrv } from '../srv/service.cds';
 
+annotate makerspaceInventorySrv.Category with @odata.draft.enabled;
+annotate makerspaceInventorySrv.Category with @UI.HeaderInfo: { TypeName: 'Category', TypeNamePlural: 'Categories', Title: { Value: name } };
+annotate makerspaceInventorySrv.Category with {
+  ID @Common.Text: { $value: name, ![@UI.TextArrangement]: #TextOnly }
+};
+annotate makerspaceInventorySrv.Category with @UI.Identification: [{ Value: name }];
+annotate makerspaceInventorySrv.Category with {
+  name @title: 'Name';
+  hardware @title: 'Hardware'
+};
+
+annotate makerspaceInventorySrv.Category with @UI.LineItem: [
+    { $Type: 'UI.DataField', Value: name },
+    { $Type: 'UI.DataField', Value: hardware }
+];
+
+annotate makerspaceInventorySrv.Category with @UI.FieldGroup #Main: {
+  $Type: 'UI.FieldGroupType', Data: [
+    { $Type: 'UI.DataField', Value: name },
+    { $Type: 'UI.DataField', Value: hardware }
+  ]
+};
+
+annotate makerspaceInventorySrv.Category with @UI.Facets: [
+  { $Type: 'UI.ReferenceFacet', ID: 'Main', Label: 'General Information', Target: '@UI.FieldGroup#Main' }
+];
+
 annotate makerspaceInventorySrv.Hardware with @odata.draft.enabled;
 annotate makerspaceInventorySrv.Hardware with @UI.HeaderInfo: { TypeName: 'Hardware', TypeNamePlural: 'Hardwares', Title: { Value: type } };
 annotate makerspaceInventorySrv.Hardware with {
@@ -8,18 +35,21 @@ annotate makerspaceInventorySrv.Hardware with {
 annotate makerspaceInventorySrv.Hardware with @UI.Identification: [{ Value: type }];
 annotate makerspaceInventorySrv.Hardware with {
   type @title: 'Type';
-  quantity @title: 'Quantity'
+  quantity @title: 'Quantity';
+  category @title: 'Category'
 };
 
 annotate makerspaceInventorySrv.Hardware with @UI.LineItem: [
     { $Type: 'UI.DataField', Value: type },
-    { $Type: 'UI.DataField', Value: quantity }
+    { $Type: 'UI.DataField', Value: quantity },
+    { $Type: 'UI.DataField', Value: category }
 ];
 
 annotate makerspaceInventorySrv.Hardware with @UI.FieldGroup #Main: {
   $Type: 'UI.FieldGroupType', Data: [
     { $Type: 'UI.DataField', Value: type },
-    { $Type: 'UI.DataField', Value: quantity }
+    { $Type: 'UI.DataField', Value: quantity },
+    { $Type: 'UI.DataField', Value: category }
   ]
 };
 

--- a/app/inmemory/db/data/makerspaceInventory-Category.csv
+++ b/app/inmemory/db/data/makerspaceInventory-Category.csv
@@ -1,0 +1,6 @@
+ID;name
+3ef42c64-b4e6-48e6-819d-c5b3d7db3ce7;3D Printing
+8e3bb4e3-324c-4a89-be57-aab021a397e0;Laser Cutting
+6325e445-6390-4a7a-bb0a-742acaf5cbdc;CNC Routing
+3e471f69-7661-45b5-aa01-7e4a5ef7e647;Soldering
+f3203325-c84a-4ce9-965c-a532c7e1800c;Electronics

--- a/app/inmemory/db/data/makerspaceInventory-Hardware.csv
+++ b/app/inmemory/db/data/makerspaceInventory-Hardware.csv
@@ -1,6 +1,6 @@
-ID;type;quantity
-3ef42c64-b4e6-48e6-819d-c5b3d7db3ce7;3D Printer;5
-8e3bb4e3-324c-4a89-be57-aab021a397e0;Laser Cutter;3
-6325e445-6390-4a7a-bb0a-742acaf5cbdc;CNC Router;2
-3e471f69-7661-45b5-aa01-7e4a5ef7e647;Soldering Iron;10
-f3203325-c84a-4ce9-965c-a532c7e1800c;Oscilloscope;4
+ID;type;quantity;category_ID
+3ef42c64-b4e6-48e6-819d-c5b3d7db3ce7;3D Printer;5;3ef42c64-b4e6-48e6-819d-c5b3d7db3ce7
+8e3bb4e3-324c-4a89-be57-aab021a397e0;Laser Cutter;3;8e3bb4e3-324c-4a89-be57-aab021a397e0
+6325e445-6390-4a7a-bb0a-742acaf5cbdc;CNC Router;2;6325e445-6390-4a7a-bb0a-742acaf5cbdc
+3e471f69-7661-45b5-aa01-7e4a5ef7e647;Soldering Iron;10;3e471f69-7661-45b5-aa01-7e4a5ef7e647
+f3203325-c84a-4ce9-965c-a532c7e1800c;Oscilloscope;4;f3203325-c84a-4ce9-965c-a532c7e1800c

--- a/app/inmemory/db/schema.cds
+++ b/app/inmemory/db/schema.cds
@@ -1,9 +1,16 @@
 namespace makerspaceInventory;
 
+entity Category {
+  key ID: UUID;
+  name: String(200);
+  hardware: Association to many Hardware on hardware.category = $self;
+}
+
 entity Hardware {
   key ID: UUID;
   type: String(200);
   quantity: Integer;
+  category: Association to Category;
 }
 
 entity Item {


### PR DESCRIPTION
This is a capGPT-generated Code Change for the following user-request: Categories should contain various hardware types that belong to that category, while still each hardware type can have multiple instances.