### PR TITLE
A category should have a title, a description and an internal ID. Categories need to be created and should be editable. Hardware types within a category should belong together, e.g. machines, manual tools or consumable material.

### DIFF
--- a/app/inmemory/app/annotations.cds
+++ b/app/inmemory/app/annotations.cds
@@ -7,18 +7,24 @@ annotate makerspaceInventorySrv.Category with {
 };
 annotate makerspaceInventorySrv.Category with @UI.Identification: [{ Value: name }];
 annotate makerspaceInventorySrv.Category with {
+  internalID @title: 'Internal ID';
   name @title: 'Name';
+  description @title: 'Description';
   hardware @title: 'Hardware'
 };
 
 annotate makerspaceInventorySrv.Category with @UI.LineItem: [
+    { $Type: 'UI.DataField', Value: internalID },
     { $Type: 'UI.DataField', Value: name },
+    { $Type: 'UI.DataField', Value: description },
     { $Type: 'UI.DataField', Value: hardware }
 ];
 
 annotate makerspaceInventorySrv.Category with @UI.FieldGroup #Main: {
   $Type: 'UI.FieldGroupType', Data: [
+    { $Type: 'UI.DataField', Value: internalID },
     { $Type: 'UI.DataField', Value: name },
+    { $Type: 'UI.DataField', Value: description },
     { $Type: 'UI.DataField', Value: hardware }
   ]
 };

--- a/app/inmemory/db/data/makerspaceInventory-Category.csv
+++ b/app/inmemory/db/data/makerspaceInventory-Category.csv
@@ -1,6 +1,6 @@
-ID;name
-3ef42c64-b4e6-48e6-819d-c5b3d7db3ce7;3D Printing
-8e3bb4e3-324c-4a89-be57-aab021a397e0;Laser Cutting
-6325e445-6390-4a7a-bb0a-742acaf5cbdc;CNC Routing
-3e471f69-7661-45b5-aa01-7e4a5ef7e647;Soldering
-f3203325-c84a-4ce9-965c-a532c7e1800c;Electronics
+ID;internalID;name;description
+3ef42c64-b4e6-48e6-819d-c5b3d7db3ce7;CAT-001;3D Printing;Used for creating 3D models
+8e3bb4e3-324c-4a89-be57-aab021a397e0;CAT-002;Laser Cutting;Used for cutting materials
+6325e445-6390-4a7a-bb0a-742acaf5cbdc;CAT-003;CNC Routing;Used for carving designs into hard materials
+3e471f69-7661-45b5-aa01-7e4a5ef7e647;CAT-004;Soldering;Used for joining metal pieces
+f3203325-c84a-4ce9-965c-a532c7e1800c;CAT-005;Electronics;Used for creating electronic circuits

--- a/app/inmemory/db/schema.cds
+++ b/app/inmemory/db/schema.cds
@@ -2,7 +2,9 @@ namespace makerspaceInventory;
 
 entity Category {
   key ID: UUID;
+  internalID: String(200);
   name: String(200);
+  description: String(2000);
   hardware: Association to many Hardware on hardware.category = $self;
 }
 


### PR DESCRIPTION
This is a capGPT-generated Code Change for the following user-request: A category should have a title, a description and an internal ID. Categories need to be created and should be editable. Hardware types within a category should belong together, e.g. machines, manual tools or consumable material.